### PR TITLE
added escape to constraint name

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/cdc/mssql/MsSqlTableMetadataProvider.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/cdc/mssql/MsSqlTableMetadataProvider.java
@@ -56,7 +56,7 @@ class MsSqlTableMetadataProvider extends CachingTableMetadataProvider {
   private static Logger log = LoggerFactory.getLogger(MsSqlTableMetadataProvider.class);
   final static String PRIMARY_KEY_SQL =
       "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE " +
-          "OBJECTPROPERTY(OBJECT_ID(CONSTRAINT_SCHEMA+'.'+CONSTRAINT_NAME), 'IsPrimaryKey') = 1 AND " +
+          "OBJECTPROPERTY(OBJECT_ID(CONSTRAINT_SCHEMA+'.['+CONSTRAINT_NAME)+']', 'IsPrimaryKey') = 1 AND " +
           "CONSTRAINT_SCHEMA = ? AND TABLE_NAME = ?";
   final static String COLUMN_DEFINITION_SQL =
       "SELECT column_name, iif(is_nullable='YES', 1, 0) AS is_optional, data_type, " +


### PR DESCRIPTION
added [] around the name in to the objectproperty call to avoid issues when users have a `.`  for example `PK_dbo.tablename` in the name of their constraint. the PK_dbo isn't the schema here but is part of the name. 

- side note
i couldn't get this repo to compile but the change is small enough to oversee the complications. if you have any pointers in compiling this repo, please let me know